### PR TITLE
Fix errors on nonexistent fields

### DIFF
--- a/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/webstack_django_sorting/templatetags/sorting_tags.py
@@ -146,7 +146,7 @@ class SortedDataNode(template.Node):
 
         if ordering:
             try:
-                if self.need_python_sorting(queryset, ordering):
+                if queryset.exists() and self.need_python_sorting(queryset, ordering) and hasattr(queryset[0], name):
                     # Fallback on pure Python sorting (much slower on large data)
 
                     # The field name can be prefixed by the minus sign and we need to

--- a/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/webstack_django_sorting/templatetags/sorting_tags.py
@@ -146,27 +146,28 @@ class SortedDataNode(template.Node):
 
         if ordering:
             try:
-                if self.need_python_sorting(queryset, ordering):
-                    # Fallback on pure Python sorting (much slower on large data)
-
-                    # The field name can be prefixed by the minus sign and we need to
-                    # extract this information if we want to sort on simple object
-                    # attributes (non-model fields)
-                    if ordering[0] == '-':
-                        if len(ordering) == 1:
-                            raise template.TemplateSyntaxError
-
-                        reverse = True
-                        name = ordering[1:]
+                if queryset.exists():
+                    if self.need_python_sorting(queryset, ordering):
+                        # Fallback on pure Python sorting (much slower on large data)
+    
+                        # The field name can be prefixed by the minus sign and we need to
+                        # extract this information if we want to sort on simple object
+                        # attributes (non-model fields)
+                        if ordering[0] == '-':
+                            if len(ordering) == 1:
+                                raise template.TemplateSyntaxError
+    
+                            reverse = True
+                            name = ordering[1:]
+                        else:
+                            reverse = False
+                            name = ordering
+                        if hasattr(queryset[0], name):
+                            context[key] = sorted(queryset, key=attrgetter(name), reverse=reverse)
+                        else:
+                            raise AttributeError()
                     else:
-                        reverse = False
-                        name = ordering
-                    if hasattr(queryset[0], name):
-                        context[key] = sorted(queryset, key=attrgetter(name), reverse=reverse)
-                    else:
-                        raise AttributeError()
-                else:
-                    context[key] = queryset.order_by(ordering)
+                        context[key] = queryset.order_by(ordering)
             except (template.TemplateSyntaxError, AttributeError):
                 # Seems spurious to me...
                 if INVALID_FIELD_RAISES_404:

--- a/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/webstack_django_sorting/templatetags/sorting_tags.py
@@ -164,7 +164,7 @@ class SortedDataNode(template.Node):
                     context[key] = sorted(queryset, key=attrgetter(name), reverse=reverse)
                 else:
                     context[key] = queryset.order_by(ordering)
-            except template.TemplateSyntaxError:
+            except (template.TemplateSyntaxError, AttributeError):
                 # Seems spurious to me...
                 if INVALID_FIELD_RAISES_404:
                     raise Http404(

--- a/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/webstack_django_sorting/templatetags/sorting_tags.py
@@ -146,7 +146,7 @@ class SortedDataNode(template.Node):
 
         if ordering:
             try:
-                if queryset.exists() and self.need_python_sorting(queryset, ordering):
+                if self.need_python_sorting(queryset, ordering):
                     # Fallback on pure Python sorting (much slower on large data)
 
                     # The field name can be prefixed by the minus sign and we need to

--- a/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/webstack_django_sorting/templatetags/sorting_tags.py
@@ -146,7 +146,7 @@ class SortedDataNode(template.Node):
 
         if ordering:
             try:
-                if queryset.exists() and self.need_python_sorting(queryset, ordering) and hasattr(queryset[0], name):
+                if queryset.exists() and self.need_python_sorting(queryset, ordering):
                     # Fallback on pure Python sorting (much slower on large data)
 
                     # The field name can be prefixed by the minus sign and we need to
@@ -161,7 +161,10 @@ class SortedDataNode(template.Node):
                     else:
                         reverse = False
                         name = ordering
-                    context[key] = sorted(queryset, key=attrgetter(name), reverse=reverse)
+                    if hasattr(queryset[0], name):
+                        context[key] = sorted(queryset, key=attrgetter(name), reverse=reverse)
+                    else:
+                        raise AttributeError()
                 else:
                     context[key] = queryset.order_by(ordering)
             except (template.TemplateSyntaxError, AttributeError):


### PR DESCRIPTION
Fix: When you visit a sorting url with a non existent fields, the server can fail and/or process a huge queryset to no avail.
