### PR TITLE
Remove deprecation warning from Django 1.8

### DIFF
--- a/webstack_django_sorting/middleware.py
+++ b/webstack_django_sorting/middleware.py
@@ -1,13 +1,13 @@
 def get_field(self):
     try:
-        field = self.REQUEST['sort']
+        field = self.GET['sort']
     except (KeyError, ValueError, TypeError):
         field = ''
     return (self.direction == 'desc' and '-' or '') + field
 
 def get_direction(self):
     try:
-        return self.REQUEST['dir']
+        return self.GET['dir']
     except (KeyError, ValueError, TypeError):
         return 'desc'
 


### PR DESCRIPTION
```
RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
```
