### PR TITLE
Add changes in nulls ordering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The project provides examples of integration with Django and Jinja2 templates.
     {% autosort object_list %}
     ```
 
-    You can pass the option `nulls_first=True` (or `nulls_first=False`) to
+    You can pass the option `nulls=first` (or `nulls=last`) to
     explicitly define the ordering of NULL (not supported by all databases,
     [Indexing ASC, DESC and NULLS
     FIRST/LAST](https://use-the-index-luke.com/sql/sorting-grouping/order-by-asc-desc-nulls-last))

--- a/testproj/testproj/testapp/templates/secret_list_nulls_first.html
+++ b/testproj/testproj/testapp/templates/secret_list_nulls_first.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h2>List of files</h2>
-    {% autosort secret_files nulls_first=True %}
+    {% autosort secret_files nulls=first %}
     <table>
       <thead>
         <tr>

--- a/testproj/testproj/testapp/templates/secret_list_nulls_last.html
+++ b/testproj/testproj/testapp/templates/secret_list_nulls_last.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h2>List of files</h2>
-    {% autosort secret_files nulls_last=True %}
+    {% autosort secret_files nulls=last %}
     <table>
       <thead>
         <tr>

--- a/webstack_django_sorting/common.py
+++ b/webstack_django_sorting/common.py
@@ -57,6 +57,8 @@ def sort_queryset(queryset, order_by, null_ordering):
     """order_by is an Django ORM order_by argument"""
 
     if not order_by:
+        # In this case the queryset can't be ordered (no field name specified)
+        # even though nulls ordering is set
         return queryset
 
     # The field name can be prefixed by the minus sign and we need to
@@ -82,3 +84,11 @@ def sort_queryset(queryset, order_by, null_ordering):
         F(name).desc if reverse else F(name).asc
     )(**null_ordering)
     return queryset.order_by(ordering_exp)
+
+
+def get_null_ordering(request, default_template_ordering):
+    # prioritize changes in url parameter over the default template variable
+    null_ordering = request.GET.get('nulls', default_template_ordering or {})
+    if null_ordering:
+        null_ordering = {f'nulls_{null_ordering}': True}
+    return null_ordering

--- a/webstack_django_sorting/jinja2_globals.py
+++ b/webstack_django_sorting/jinja2_globals.py
@@ -7,8 +7,7 @@ def sorting_anchor(request, field_name, title):
     return Markup(common.render_sort_anchor(request, field_name, title))
 
 
-def sort_queryset(request, queryset, **null_ordering):
-    if not null_ordering:
-        null_ordering = {}
+def sort_queryset(request, queryset, **context_var):
     order_by = common.get_order_by_from_request(request)
+    null_ordering = common.get_null_ordering(request, context_var.get("nulls"))
     return common.sort_queryset(queryset, order_by, null_ordering)


### PR DESCRIPTION
Instead of 'nulls_first=True' and 'nulls_last=True' specify directly the direction
with the parameter 'nulls' (either 'nulls=first' or 'nulls=last').

Sorry for the wait, I've made the changes requested (in the last commit i've made)
If anything doesn't seems clear I would gladly explain or make the related changes 😄