### PR TITLE
Removed ipdb import

### DIFF
--- a/src/webstack_django_sorting/templatetags/sorting_tags.py
+++ b/src/webstack_django_sorting/templatetags/sorting_tags.py
@@ -35,7 +35,6 @@ def anchor(parser, token):
     except IndexError:
         title = bits[1].capitalize()
 
-    __import__("ipdb").set_trace()
     default_sort_order = (
         "desc" if len(bits) >= 4 and bits[3].strip("'\"") == "desc" else "asc"
     )


### PR DESCRIPTION
Looks like this was accidentally introduced in https://github.com/webstack/webstack-django-sorting/commit/3098d78da8d97a56a616b928e88c6fc7eabc93a0#diff-c4502179f57e500eeb37f53678e5d81a5e50fddc5a2f6de9303f8848193dfc52R38

We've just upgraded and had failures in the CI